### PR TITLE
feat: Add goreleaser config from scaffolding repo

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,64 @@
+version: 2
+builds:
+  - env:
+      # goreleaser does not work with CGO, it could also complicate
+      # usage by users in CI/CD systems like Terraform Cloud where
+      # they are unable to install libraries.
+      - CGO_ENABLED=0
+    mod_timestamp: "{{ .CommitTimestamp }}"
+    flags:
+      - -trimpath
+    ldflags:
+      - "-s -w -X main.version={{.Version}} -X main.commit={{.Commit}}"
+    goos:
+      - freebsd
+      - windows
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - "386"
+      - arm
+      - arm64
+    ignore:
+      # Exclude the following combinations because they are not officially supported by Terraform
+      # See https://www.terraform.io/registry/providers/os-arch
+      # See https://releases.hashicorp.com/terraform/1.1.4/
+      - goos: darwin
+        goarch: "386"
+      - goos: darwin
+        goarch: "arm"
+      - goos: freebsd
+        goarch: "arm64"
+      - goos: windows
+        goarch: "arm"
+      - goos: windows
+        goarch: "arm64"
+    binary: "{{ .ProjectName }}_v{{ .Version }}"
+archives:
+  - format: zip
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+checksum:
+  extra_files:
+    - glob: "terraform-registry-manifest.json"
+      name_template: "{{ .ProjectName }}_{{ .Version }}_manifest.json"
+  name_template: "{{ .ProjectName }}_{{ .Version }}_SHA256SUMS"
+  algorithm: sha256
+signs:
+  - artifacts: checksum
+    args:
+      # if you are using this in a GitHub action or some other automated pipeline, you
+      # need to pass the batch flag to indicate its not interactive.
+      - "--batch"
+      - "--local-user"
+      - "{{ .Env.GPG_FINGERPRINT }}" # set this environment variable for your signing key
+      - "--output"
+      - "${signature}"
+      - "--detach-sign"
+      - "${artifact}"
+release:
+  extra_files:
+    - glob: "terraform-registry-manifest.json"
+      name_template: "{{ .ProjectName }}_{{ .Version }}_manifest.json"
+  # If you want to manually examine the release before its live, uncomment this line:
+  # draft: true


### PR DESCRIPTION
This is the recommended way of creating releases for terraform-providers

https://github.com/hashicorp/terraform-provider-scaffolding-framework/blob/main/.goreleaser.yml
