### PR TITLE
feat: Update goreleaser config to include more targets

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -23,32 +23,22 @@ builds:
     ignore:
       # Exclude the following combinations because they are not officially supported by Terraform
       # See https://www.terraform.io/registry/providers/os-arch
-      # See https://releases.hashicorp.com/terraform/1.1.4/
+      # See https://releases.hashicorp.com/terraform/1.5.7/
       - goos: darwin
         goarch: "386"
-      - goos: darwin
-        goarch: "arm"
-      - goos: freebsd
-        goarch: "arm64"
-      - goos: windows
-        goarch: "arm"
-      - goos: windows
-        goarch: "arm64"
     binary: "{{ .ProjectName }}_v{{ .Version }}"
 archives:
   - format: zip
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
 checksum:
+  name_template: "{{ .ProjectName }}_{{ .Version }}_SHA256SUMS"
   extra_files:
     - glob: "terraform-registry-manifest.json"
       name_template: "{{ .ProjectName }}_{{ .Version }}_manifest.json"
-  name_template: "{{ .ProjectName }}_{{ .Version }}_SHA256SUMS"
   algorithm: sha256
 signs:
   - artifacts: checksum
     args:
-      # if you are using this in a GitHub action or some other automated pipeline, you
-      # need to pass the batch flag to indicate its not interactive.
       - "--batch"
       - "--local-user"
       - "{{ .Env.GPG_FINGERPRINT }}" # set this environment variable for your signing key
@@ -60,5 +50,7 @@ release:
   extra_files:
     - glob: "terraform-registry-manifest.json"
       name_template: "{{ .ProjectName }}_{{ .Version }}_manifest.json"
-  # If you want to manually examine the release before its live, uncomment this line:
-  # draft: true
+changelog:
+  disable: true
+snapshot:
+  name_template: "{{.ShortCommit}}-dev"


### PR DESCRIPTION
Support from Terraform stated that we were missing som assets in each release, and referenced https://github.com/cloudflare/terraform-provider-cloudflare/releases/tag/v4.38.0 as an example. I have copied most of the goreleaser-config from that repo, even though Linux+AMD64 is listed as the only **required** target in their [own docs](https://developer.hashicorp.com/terraform/registry/providers/os-arch).