### PR TITLE
refactor!: Rename "gpg" to "opengpg"

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 The GPG provider allows to generate GPG encrypted message in ASCII-armored format
 using Terraform. It is a fork of [invidian/terraform-provider-gpg](https://github.com/invidian/terraform-provider-gpg).
+The provider, and it's resources has been renamed from `gpg` to `opengpg`, to make
+a clearer distinction between the two providers.
 
 The provider has been forked to add support for newer encryption-algorithms,
 such as [Curve25519](https://en.wikipedia.org/wiki/Curve25519).

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,25 +14,25 @@ Managing GPG keyring or signing files is currently not implemented.
 ```hcl
 terraform {
   required_providers {
-    gpg = {
+    opengpg = {
       source  = "coopnorge/opengpg"
-      version = "0.1.0"
+      version = "0.2.0"
     }
   }
 }
 
-resource "gpg_encrypted_message" "example" {
+resource "opengpg_encrypted_message" "example" {
   content     = "This is example of GPG encrypted message."
   public_keys = [
-    var.gpg_public_key,
+    var.opengpg_public_key,
   ]
 }
 
-output "gpg_encrypted_message" {
-  value = gpg_encrypted_message.example.result
+output "opengpg_encrypted_message" {
+  value = opengpg_encrypted_message.example.result
 }
 
-variable "gpg_public_key" {
+variable "opengpg_public_key" {
   default = <<EOF
 -----BEGIN PGP PUBLIC KEY BLOCK-----
 

--- a/docs/resources/encrypted-message.md
+++ b/docs/resources/encrypted-message.md
@@ -14,14 +14,14 @@ some storage (e.g. GCS bucket).
 ## Example Usage
 
 ```hcl
-resource "gpg_encrypted_message" "example" {
+resource "opengpg_encrypted_message" "example" {
   content     = "This is example of GPG encrypted message."
   public_keys = [
-    var.gpg_public_key,
+    var.opengpg_public_key,
   ]
 }
 
-variable "gpg_public_key" {
+variable "opengpg_public_key" {
   default = <<EOF
 -----BEGIN PGP PUBLIC KEY BLOCK-----
 

--- a/gpg/doc.go
+++ b/gpg/doc.go
@@ -1,2 +1,0 @@
-// Package gpg contains implementation of terraform-provider-opengpg.
-package gpg

--- a/main.go
+++ b/main.go
@@ -3,11 +3,11 @@ package main
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
 
-	"github.com/coopnorge/terraform-provider-opengpg/gpg"
+	"github.com/coopnorge/terraform-provider-opengpg/opengpg"
 )
 
 func main() {
 	plugin.Serve(&plugin.ServeOpts{
-		ProviderFunc: gpg.Provider,
+		ProviderFunc: opengpg.Provider,
 	})
 }

--- a/opengpg/doc.go
+++ b/opengpg/doc.go
@@ -1,0 +1,2 @@
+// Package opengpg contains implementation of terraform-provider-opengpg.
+package opengpg

--- a/opengpg/provider.go
+++ b/opengpg/provider.go
@@ -1,4 +1,4 @@
-package gpg
+package opengpg
 
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -9,7 +9,7 @@ import (
 func Provider() *schema.Provider {
 	return &schema.Provider{
 		ResourcesMap: map[string]*schema.Resource{
-			"gpg_encrypted_message": resourceGPGEncryptedMessage(),
+			"opengpg_encrypted_message": resourceGPGEncryptedMessage(),
 		},
 	}
 }

--- a/opengpg/provider_test.go
+++ b/opengpg/provider_test.go
@@ -1,9 +1,9 @@
-package gpg_test
+package opengpg_test
 
 import (
 	"testing"
 
-	"github.com/coopnorge/terraform-provider-opengpg/gpg"
+	"github.com/coopnorge/terraform-provider-opengpg/opengpg"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -11,15 +11,15 @@ import (
 // The factory function will be invoked for every Terraform CLI command executed
 // to create a provider server to which the CLI can reattach.
 var providerFactories = map[string]func() (*schema.Provider, error){
-	"gpg": func() (*schema.Provider, error) {
-		return gpg.Provider(), nil
+	"opengpg": func() (*schema.Provider, error) {
+		return opengpg.Provider(), nil
 	},
 }
 
 func TestProvider(t *testing.T) {
 	t.Parallel()
 
-	provider := gpg.Provider()
+	provider := opengpg.Provider()
 
 	if err := provider.InternalValidate(); err != nil {
 		t.Fatalf("validating provider internally: %v", err)

--- a/opengpg/resource_gpg_encrypted_message.go
+++ b/opengpg/resource_gpg_encrypted_message.go
@@ -1,4 +1,4 @@
-package gpg
+package opengpg
 
 import (
 	"bytes"

--- a/opengpg/resource_gpg_encrypted_message_test.go
+++ b/opengpg/resource_gpg_encrypted_message_test.go
@@ -1,38 +1,25 @@
-package gpg
+package opengpg_test
 
 import (
+	"regexp"
+	"strings"
 	"testing"
 
-	protonpgp "github.com/ProtonMail/gopenpgp/v3/crypto"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-func TestEncryptMessage(t *testing.T) {
-	recipient, err := entityFromString(publicKeyRSA)
-	require.NoError(t, err)
-	recipients := []*protonpgp.Key{
-		recipient,
-	}
-	message := "hello world"
-	result, err := encryptAndEncodeMessage(recipients, message)
-	require.NoError(t, err)
-	assert.True(t, protonpgp.IsPGPMessage(result), "encrypted messages is not PGP message")
+const rsaConfig = `
+resource "opengpg_encrypted_message" "example" {
+  content     = "This is example of GPG encrypted message."
+  public_keys = [
+    var.opengpg_public_key_rsa,
+  ]
 }
 
-func TestEncryptMessageCurve(t *testing.T) {
-	recipient, err := entityFromString(publicKeyCurve)
-	require.NoError(t, err)
-	recipients := []*protonpgp.Key{
-		recipient,
-	}
-	message := "hello world"
-	result, err := encryptAndEncodeMessage(recipients, message)
-	require.NoError(t, err)
-	assert.True(t, protonpgp.IsPGPMessage(result), "encrypted messages is not PGP message")
-}
-
-var publicKeyRSA = `-----BEGIN PGP PUBLIC KEY BLOCK-----
+variable "opengpg_public_key_rsa" {
+  description = "A public-key of type RSA 4096, using the SHA256 hashing algorithm"
+  default = <<EOF
+-----BEGIN PGP PUBLIC KEY BLOCK-----
 
 mQINBGbpjbsBEADXTqjVkXhDOl0iNmhdOgOmHsP7QSnOV8uYdRi4Pq4i+SZyMOMJ
 v3xeV3etB+xV3CkTe1BiBakG0DfTOnXDBW74g9VFhb4N3TNvggj0qx1fEDuQdqv/
@@ -82,9 +69,23 @@ U0p5LqG3+eVrqx5h1qogij/g4vuH4nc+CAM6TDaeCZpxvfSUj3DKywmmtnzmBGZy
 0xv/l1vp92dP7aboxptVk+9z8DXIsm1g98vLYEztfydn9fm61GrNhkEmMhlhXxKc
 Su/0YRS5KEtg0LAiIcQH7gYvmXTsl1Xb3gElCVWqGr1lSBAX8KUq1VI=
 =lZG6
------END PGP PUBLIC KEY BLOCK-----`
+-----END PGP PUBLIC KEY BLOCK-----
+EOF
+}
+`
 
-var publicKeyCurve = `-----BEGIN PGP PUBLIC KEY BLOCK-----
+const ecc25519Config = `
+resource "opengpg_encrypted_message" "example" {
+  content     = "This is example of GPG encrypted message."
+  public_keys = [
+    var.opengpg_public_key_ecc25519,
+  ]
+}
+
+variable "opengpg_public_key_ecc25519" {
+  description = "A public-key of type ECC 25519, using the SHA512 hashing algorithm"
+  default = <<EOF
+-----BEGIN PGP PUBLIC KEY BLOCK-----
 
 mDMEZumPqxYJKwYBBAHaRw8BAQdAbEfcyIa1K25/DMwIocm+MfYYAF3jlq8+GxjY
 7FjzZ9S0LGZvb2Jhci1lY2MyNTUxOSAoZm9vYmFyKSA8Zm9vQGJhci1jdXJ2ZS5j
@@ -96,4 +97,103 @@ szkpBnI3TlJQqUeLaTYDAQgHiHgEGBYKACAWIQT3olI2/t6HX2MIvmYnB22SxES8
 hwUCZumPqwIbDAAKCRAnB22SxES8h/ErAQDlnDX+BRfsGyPR+WzhnTCV+fUvaWsG
 wCnk1/Lh1fpGhAEAhFokVxfOaontUAnC/dDsxSZ7KdLVgOOuwZskhidIagk=
 =1j0l
------END PGP PUBLIC KEY BLOCK-----`
+-----END PGP PUBLIC KEY BLOCK-----
+EOF
+}
+`
+
+const badPublicKey = `
+resource "opengpg_encrypted_message" "example" {
+  content     = "This is example of GPG encrypted message."
+  public_keys = [
+		"not valid message",
+  ]
+}
+`
+
+const badPublicKeyPEMEncoded = `
+resource "opengpg_encrypted_message" "example" {
+  content     = "This is example of GPG encrypted message."
+	public_keys = [
+		<<EOF
+-----BEGIN PGP PUBLIC KEY BLOCK-----
+
+bm9wZQo=
+-----END PGP PUBLIC KEY BLOCK-----
+EOF
+		,
+	]
+}
+
+`
+
+const noPublicKeys = `
+resource "opengpg_encrypted_message" "example" {
+  content     = "This is example of GPG encrypted message."
+  public_keys = []
+}
+`
+
+func TestGPGEncryptedMessageRSA(t *testing.T) {
+	t.Parallel()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProviderFactories: providerFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: rsaConfig,
+			},
+			{
+				Config:             rsaConfig,
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+			{
+				Config:      badPublicKey,
+				ExpectError: regexp.MustCompile(`decoding public key #0: decoding public key: gopenpgp: error in reading key ring: openpgp: invalid data: tag byte does not have MSB set`),
+			},
+			{
+				Config:      badPublicKeyPEMEncoded,
+				ExpectError: regexp.MustCompile(`decoding public key #0: decoding public key: gopenpgp: error in reading key ring: openpgp: invalid data: tag byte does not have MSB set`),
+			},
+		},
+	})
+}
+
+func TestGPGEncryptedMessageECC25519(t *testing.T) {
+	t.Parallel()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProviderFactories: providerFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: ecc25519Config,
+			},
+			{
+				Config:             ecc25519Config,
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
+func TestGPGEncryptedMessageBadArguments(t *testing.T) {
+	t.Parallel()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProviderFactories: providerFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      noPublicKeys,
+				ExpectError: regexp.MustCompile(regexSpaceOrNewline(`Attribute public_keys requires 1 item minimum, but config has only 0 declared.`)),
+				Destroy:     false,
+			},
+		},
+	})
+}
+
+// regexSpaceOrNewline allows a string's spaces to be either a normal space or a newline. This is to allow less brittle tests when terraform changes their output
+func regexSpaceOrNewline(str string) string {
+	return strings.ReplaceAll(str, " ", "[\\ \\n]")
+}


### PR DESCRIPTION
Complete the rename of the provider-name (in docs/examples/tests), go-package-name, and resource-names from "gpg" to "opengpg".

Renaming the resource-name from "gpg_encrypted_message" to "opengpg_encrypted_message" is a breaking change, so we want to do this before anyone starts using the provider. Terraform's best practices recommend using the provider's name as the prefix for resource-names: https://developer.hashicorp.com/terraform/plugin/best-practices/naming#resource-names
