### PR TITLE
build: Re-add changelogs from goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -50,7 +50,5 @@ release:
   extra_files:
     - glob: "terraform-registry-manifest.json"
       name_template: "{{ .ProjectName }}_{{ .Version }}_manifest.json"
-changelog:
-  disable: true
 snapshot:
-  name_template: "{{.ShortCommit}}-dev"
+  version_template: "{{.ShortCommit}}-dev"


### PR DESCRIPTION
Now that we have confirmed that we are able to create proper releases, we can re-add the changelog-generation from goreleaser.

Also renames `snapshot.name_template` to `snapshot.version_template`, according to the deprecation-warnings: https://goreleaser.com/deprecations/#snapshotnametemplate
