### PR TITLE
lint: Lowercase error-string

### DIFF
--- a/opengpg/resource_gpg_encrypted_message.go
+++ b/opengpg/resource_gpg_encrypted_message.go
@@ -106,7 +106,7 @@ func resourceGPGEncryptedMessageCreate(data *schema.ResourceData, _ any) error {
 
 	plaintextMessage, ok := data.Get("content").(string)
 	if !ok {
-		return fmt.Errorf("Data in property %q was not a string", "content")
+		return fmt.Errorf("data in property %q was not a string", "content")
 	}
 
 	encryptedMessage, err := encryption.EncryptAndEncodeMessage(recipients, plaintextMessage)


### PR DESCRIPTION
This was detected in the newest version of the devtools (new version of golangci-lint): https://github.com/coopnorge/terraform-provider-opengpg/pull/78
